### PR TITLE
Feat/generate new token when refresh instead of refreshing

### DIFF
--- a/app/Http/Controllers/AuthController.php
+++ b/app/Http/Controllers/AuthController.php
@@ -69,7 +69,14 @@ class AuthController extends Controller
         $remember = $request->input('remember', false);
 
         try {
-            $token = $auth->parseToken()->refresh();
+            $user = $auth->user();
+
+            $auth->parseToken();
+            $auth->invalidate(true);
+            $auth->unsetToken();
+
+            $token = $auth->fromUser($user);
+
             $tokenCookie = $this->makeAuthorizationTokenCookie($token, $remember);
 
             return response()

--- a/app/Http/Controllers/AuthController.php
+++ b/app/Http/Controllers/AuthController.php
@@ -87,7 +87,7 @@ class AuthController extends Controller
                     'ttl' => config('jwt.ttl'),
                     'refresh_ttl' => config('jwt.refresh_ttl')
                 ])
-                ->withHeaders(['Authorization' => "Bearer {$token}"])
+                ->withHeaders(['Authorization' => "Bearer {$newToken}"])
                 ->withCookie($tokenCookie);
         } catch (JWTException $e) {
             throw new UnauthorizedHttpException('jwt-auth', $e->getMessage(), $e, $e->getCode());

--- a/tests/AuthTest.php
+++ b/tests/AuthTest.php
@@ -164,11 +164,11 @@ class AuthTest extends TestCase
         $response = $request->json('get', '/auth/refresh');
 
         $authHeader = $response->headers->get('authorization');
-        $explodedHeader = explode(' ', $authHeader);
+        list(, $newToken) = explode(' ', $authHeader);
 
         $this->assertNotEquals(
             $this->decodeJWTToken($this->token)->iat,
-            $this->decodeJWTToken(last($explodedHeader))->iat
+            $this->decodeJWTToken($newToken)->iat
         );
     }
 

--- a/tests/AuthTest.php
+++ b/tests/AuthTest.php
@@ -119,7 +119,11 @@ class AuthTest extends TestCase
 
     public function testRefreshToken()
     {
-        $response = $this->actingAs($this->admin)->json('get', '/auth/refresh');
+        $request = $this->actingAs($this->admin);
+
+        $this->travel(config('jwt.ttl') + 1)->minutes();
+
+        $response = $request->json('get', '/auth/refresh');
 
         $response->assertStatus(Response::HTTP_OK);
 

--- a/tests/AuthTest.php
+++ b/tests/AuthTest.php
@@ -147,6 +147,17 @@ class AuthTest extends TestCase
         $this->assertNotEquals($this->token, last($explodedCookie));
     }
 
+    public function refreshTokenAfterRefreshTTL()
+    {
+        $request = $this->actingAs($this->admin);
+
+        $this->travel(config('jwt.refresh_ttl') + 1)->minutes();
+
+        $response = $request->json('get', '/auth/refresh');
+
+        $response->assertStatus(Response::HTTP_UNAUTHORIZED);
+    }
+
     public function testRefreshTokenWithRemember()
     {
         $response = $this->actingAs($this->admin)->json('get', '/auth/refresh', [

--- a/tests/AuthTest.php
+++ b/tests/AuthTest.php
@@ -155,6 +155,25 @@ class AuthTest extends TestCase
         $response->assertCookieNotExpired('token');
     }
 
+    public function testRefreshTokenIat()
+    {
+        $request = $this->actingAs($this->admin);
+
+        $currentTokenIat = $this->decodeJWTToken($this->token)->iat;
+
+        $this->travel(1)->second();
+
+        $response = $request->json('get', '/auth/refresh');
+
+        $authHeader = $response->headers->get('authorization');
+        $explodedHeader = explode(' ', $authHeader);
+
+        $this->assertNotEquals(
+            $currentTokenIat,
+            $this->decodeJWTToken(last($explodedHeader))->iat
+        );
+    }
+
     public function testLogout()
     {
         $response = $this->actingAs($this->admin)->json('post', '/auth/logout');

--- a/tests/AuthTest.php
+++ b/tests/AuthTest.php
@@ -159,8 +159,6 @@ class AuthTest extends TestCase
     {
         $request = $this->actingAs($this->admin);
 
-        $currentTokenIat = $this->decodeJWTToken($this->token)->iat;
-
         $this->travel(1)->second();
 
         $response = $request->json('get', '/auth/refresh');
@@ -169,7 +167,7 @@ class AuthTest extends TestCase
         $explodedHeader = explode(' ', $authHeader);
 
         $this->assertNotEquals(
-            $currentTokenIat,
+            $this->decodeJWTToken($this->token)->iat,
             $this->decodeJWTToken(last($explodedHeader))->iat
         );
     }

--- a/tests/Support/AuthTestTrait.php
+++ b/tests/Support/AuthTestTrait.php
@@ -15,4 +15,17 @@ trait AuthTestTrait
             ['method' => 'generateHash', 'result' => $hash]
         ]);
     }
+
+    public function decodeJWTToken($token)
+    {
+        return json_decode(
+            base64_decode(
+                str_replace(
+                    '_',
+                    '/',
+                    str_replace('-','+',explode('.', $token)[1])
+                )
+            )
+        );
+    }
 }

--- a/tests/Support/AuthTestTrait.php
+++ b/tests/Support/AuthTestTrait.php
@@ -23,7 +23,7 @@ trait AuthTestTrait
                 str_replace(
                     '_',
                     '/',
-                    str_replace('-','+',explode('.', $token)[1])
+                    str_replace('-', '+', explode('.', $token)[1])
                 )
             )
         );


### PR DESCRIPTION
https://medium.com/@sirajul.anik/understanding-the-tymon-jwt-auth-refresh-token-mechanism-when-why-jwt-ttl-jwt-refresh-ttl-97cc0019c02f