### PR TITLE
test: remove ignore and mock openssl_random_pseudo_bytes

### DIFF
--- a/app/Services/UserService.php
+++ b/app/Services/UserService.php
@@ -77,9 +77,6 @@ class UserService extends EntityService
             ]);
     }
 
-    /**
-     * @codeCoverageIgnore
-     */
     protected function generateHash(int $length = 32): string
     {
         $length /= 2;

--- a/tests/AuthTest.php
+++ b/tests/AuthTest.php
@@ -242,7 +242,7 @@ class AuthTest extends TestCase
     {
         Mail::fake();
 
-        $this->mockUniqueTokenGeneration('some_token');
+        $this->mockOpensslRandomPseudoBytes();
 
         $response = $this->json('post', '/auth/forgot-password', [
             'email' => 'fidel.kutch@example.com'

--- a/tests/Support/AuthTestTrait.php
+++ b/tests/Support/AuthTestTrait.php
@@ -2,18 +2,19 @@
 
 namespace App\Tests\Support;
 
-use App\Services\UserService;
+use phpmock\phpunit\PHPMock;
 use RonasIT\Support\Traits\MockClassTrait;
 
 trait AuthTestTrait
 {
-    use MockClassTrait;
+    use MockClassTrait, PHPMock;
 
-    public function mockUniqueTokenGeneration($hash)
+    public function mockOpensslRandomPseudoBytes(): void
     {
-        $this->mockClass(UserService::class, [
-            ['method' => 'generateHash', 'result' => $hash]
-        ]);
+        $mock = $this->getFunctionMock('App\Services', 'openssl_random_pseudo_bytes');
+        $mock
+            ->expects($this->once())
+            ->willReturn('5qw6rdsyd4sa65d4zxfc65ds4fc');
     }
 
     public function decodeJWTToken($token)

--- a/tests/fixtures/AuthTest/forgot_password_email.html
+++ b/tests/fixtures/AuthTest/forgot_password_email.html
@@ -61,7 +61,7 @@
                                                style="font-family: Avenir, Helvetica, sans-serif; box-sizing: border-box;">
                                             <tr>
                                                 <td style="font-family: Avenir, Helvetica, sans-serif; box-sizing: border-box;">
-                                                    <a href="http://localhost/enter-new-password/some_token"
+                                                    <a href="http://localhost/enter-new-password/357177367264737964347361363564347a78666336356473346663"
                                                        class="button button-blue" target="_blank"
                                                        style="font-family: Avenir, Helvetica, sans-serif; box-sizing: border-box; border-radius: 3px; box-shadow: 0 2px 3px rgba(0, 0, 0, 0.16); color: #FFF; display: inline-block; text-decoration: none; -webkit-text-size-adjust: none; background-color: #3097D1; border-top: 10px solid #3097D1; border-right: 18px solid #3097D1; border-bottom: 10px solid #3097D1; border-left: 18px solid #3097D1;">Reset
                                                         Password</a>
@@ -85,9 +85,9 @@
                             <p style="font-family: Avenir, Helvetica, sans-serif; box-sizing: border-box; color: #74787E; line-height: 1.5em; margin-top: 0; text-align: left; font-size: 12px;">
                                 If you’re having trouble clicking the "Reset Password" button, copy and paste the URL
                                 below into your web browser:
-                                <a href="http://localhost/enter-new-password/some_token" style="font-family: Avenir, Helvetica, sans-serif; box-sizing: border-box; color: #3869D4;"></a>
-                                <a href="http://localhost/enter-new-password/some_token" style="font-family: Avenir, Helvetica, sans-serif; box-sizing: border-box; color: #3869D4;">
-                                    http://localhost/enter-new-password/some_token
+                                <a href="http://localhost/enter-new-password/357177367264737964347361363564347a78666336356473346663" style="font-family: Avenir, Helvetica, sans-serif; box-sizing: border-box; color: #3869D4;"></a>
+                                <a href="http://localhost/enter-new-password/357177367264737964347361363564347a78666336356473346663" style="font-family: Avenir, Helvetica, sans-serif; box-sizing: border-box; color: #3869D4;">
+                                    http://localhost/enter-new-password/357177367264737964347361363564347a78666336356473346663
                                 </a>
                             </p>
                         </td>


### PR DESCRIPTION
I removed `@codeCoverageIgnore` from the `generateHash` function and implemented mocking for the `openssl_random_pseudo_bytes` instead.