### PR TITLE
#145: Mock class not assert arguments with the empty arg list

### DIFF
--- a/tests/AuthTest.php
+++ b/tests/AuthTest.php
@@ -102,7 +102,7 @@ class AuthTest extends TestCase
 
     public function testRegisterAuthorizedUser()
     {
-        $this->mockBcryptHasher();
+        $this->mockBcryptHasher('666999');
 
         $data = $this->getJsonFixture('new_user.json');
 
@@ -115,7 +115,7 @@ class AuthTest extends TestCase
 
     public function testRegisterFromGuestUser()
     {
-        $this->mockBcryptHasher();
+        $this->mockBcryptHasher('666999');
 
         $data = $this->getJsonFixture('new_user.json');
 
@@ -290,7 +290,7 @@ class AuthTest extends TestCase
 
     public function testRestorePassword()
     {
-        $this->mockBcryptHasher();
+        $this->mockBcryptHasher('new_password');
 
         $data = $this->getJsonFixture('restore_password.json');
 

--- a/tests/Support/AuthTestTrait.php
+++ b/tests/Support/AuthTestTrait.php
@@ -9,21 +9,25 @@ trait AuthTestTrait
 {
     use MockTrait;
 
-    public function mockOpensslRandomPseudoBytes(): void
+    public function mockOpensslRandomPseudoBytes(string $password): void
     {
+        //hash_hmac('sha256', $password, 'b"DÉV&´G"áËa\x1Ae&õš,Ü\x16½\x1A\x15‘\x07CM—ºSVxÅ\x16"');
+
         $this->mockNativeFunction('Illuminate\Auth\Passwords', [
             $this->functionCall(
                 name: 'hash_hmac',
+                arguments: ['sha256', $password, 'b"DÉV&´G"áËa\x1Ae&õš,Ü\x16½\x1A\x15‘\x07CM—ºSVxÅ\x16"'],
                 result: '5qw6rdsyd4sa65d4zxfc65ds4fc',
             ),
         ]);
     }
 
-    public function mockBcryptHasher(): void
+    public function mockBcryptHasher(string $password): void
     {
         $this->mockNativeFunction('Illuminate\Hashing', [
             $this->functionCall(
                 name: 'password_hash',
+                arguments: [$password, PASSWORD_DEFAULT, ['cost' => 12]],
                 result: '$2y$12$p9Bub8AaSl7EHfoGMgaXReK7Cs50kjHswxzNPTB5B4mcoRWfHnv7u',
             ),
         ]);

--- a/tests/UserTest.php
+++ b/tests/UserTest.php
@@ -28,7 +28,7 @@ class UserTest extends TestCase
 
     public function testCreate()
     {
-        $this->mockBcryptHasher();
+        $this->mockBcryptHasher('123123');
 
         $data = $this->getJsonFixture('create_user.json');
 


### PR DESCRIPTION
https://github.com/RonasIT/laravel-helpers/issues/145

depends on https://github.com/RonasIT/laravel-helpers/pull/170