### PR TITLE
task: Update routes

### DIFF
--- a/routes/api.php
+++ b/routes/api.php
@@ -14,9 +14,9 @@ Route::prefix('v{version}')
 
                 Route::controller(UserController::class)->group(function () {
                     Route::post('users', 'create');
-                    Route::put('users/{id}', 'update');
-                    Route::delete('users/{id}', 'delete');
-                    Route::get('users/{id}', 'get');
+                    Route::put('users/{id}', 'update')->whereNumber('id');
+                    Route::delete('users/{id}', 'delete')->whereNumber('id');
+                    Route::get('users/{id}', 'get')->whereNumber('id');
                     Route::get('users', 'search');
                     Route::get('profile', 'profile');
                     Route::put('profile', 'updateProfile');

--- a/tests/UserTest.php
+++ b/tests/UserTest.php
@@ -260,6 +260,15 @@ class UserTest extends TestCase
         $this->assertEqualsFixture('get_user', $response->json());
     }
 
+    public function testGetWrongUrl()
+    {
+        $response = $this->actingAs(self::$admin)->json('get', '/users/test');
+
+        $response->assertNotFound();
+
+        $response->assertJson(['error' => 'The route v0.1/users/test could not be found.']);
+    }
+
     public function testGetNotExists()
     {
         $response = $this->actingAs(self::$admin)->json('get', '/users/0');

--- a/tests/UserTest.php
+++ b/tests/UserTest.php
@@ -260,13 +260,25 @@ class UserTest extends TestCase
         $this->assertEqualsFixture('get_user', $response->json());
     }
 
-    public function testGetWrongUrl()
+    public function testGetIdParamAsString()
     {
         $response = $this->actingAs(self::$admin)->json('get', '/users/test');
 
         $response->assertNotFound();
+    }
 
-        $response->assertJson(['error' => 'The route v0.1/users/test could not be found.']);
+    public function testPutIdParamAsString()
+    {
+        $response = $this->actingAs(self::$admin)->json('put', '/users/test');
+
+        $response->assertNotFound();
+    }
+
+    public function testDeleteIdParamAsString()
+    {
+        $response = $this->actingAs(self::$admin)->json('delete', '/users/test');
+
+        $response->assertNotFound();
     }
 
     public function testGetNotExists()


### PR DESCRIPTION
Added `whereNumber('id')` validation to all routes with id path parameters to enforce numeric-only values. 